### PR TITLE
Add libraries to `Makefile` so AMY compiles on RPi/ARM/32-bit Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 # Makefile for libamy , including an example
 
 TARGET = amy-example amy-message
-LIBS = -lpthread  -lm  -ldl  -latomic
+LIBS = -lpthread  -lm
+ifeq ($(shell uname -m), armv7l)
+LIBS += -ldl  -latomic
+endif
 CC = gcc
 CFLAGS = -g -Wall -Wno-strict-aliasing 
 EMSCRIPTEN_OPTIONS = -s WASM=1 \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for libamy , including an example
 
 TARGET = amy-example amy-message
-LIBS = -lpthread  -lm 
+LIBS = -lpthread  -lm  -ldl  -latomic
 CC = gcc
 CFLAGS = -g -Wall -Wno-strict-aliasing 
 EMSCRIPTEN_OPTIONS = -s WASM=1 \

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@
 
 TARGET = amy-example amy-message
 LIBS = -lpthread  -lm
+
+# on Raspberry Pi, at least under 32-bit mode, libatomic and libdl are needed.
 ifeq ($(shell uname -m), armv7l)
 LIBS += -ldl  -latomic
 endif
+
 CC = gcc
 CFLAGS = -g -Wall -Wno-strict-aliasing 
 EMSCRIPTEN_OPTIONS = -s WASM=1 \


### PR DESCRIPTION
As per https://github.com/bwhitman/amy/issues/25
Tested on RPi3.