### PR TITLE
Allow patches to be added at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Here's the full list:
 | s    | pitch_bend | float | Sets the global pitch bend, by default modifying all note frequencies by (fractional) octaves up or down |
 | T    | bp0_target | uint mask | Which parameter bp0 controls. 1=amp, 2=duty, 4=freq, 8=filter freq, 16=resonance, 32=feedback (can be added together). Can add 64 for linear ramp, otherwise exponential. **Deprecated** for setting targets, subsumbed by ControlCoefficients. |
 | t    | timestamp | uint | ms of expected playback since some fixed start point on your host. you should always give this if you can. |
+| u    | store_patch | number,string | store up to 32 patches in RAM with ID number (1024-1055) and AMY message after a comma. Must be sent alone |  
 | v    | osc | uint 0 to OSCS-1 | which oscillator to control | 
 | V    | volume | float 0-10 | volume knob for entire synth, default 1.0 | 
 | w    | wave | uint 0-11 | waveform: [0=SINE, PULSE, SAW_DOWN, SAW_UP, TRIANGLE, NOISE, KS, PCM, ALGO, PARTIAL, PARTIALS, OFF]. default: 0/SINE |

--- a/amy.py
+++ b/amy.py
@@ -79,11 +79,13 @@ def trunc3(number):
 
 # Construct an AMY message
 def message(osc=0, wave=None, patch=None, note=None, vel=None, amp=None, freq=None, duty=None, feedback=None, time=None, reset=None, phase=None, pan=None,
-            client=None, retries=None, volume=None, pitch_bend=None, filter_freq = None, resonance = None, bp0=None, bp1=None, bp0_target=None, bp1_target=None, mod_target=None,
-            debug=None, chained_osc=None, mod_source=None, clone_osc=None, eq_l = None, eq_m = None, eq_h = None, filter_type= None, algorithm=None, ratio = None, latency_ms = None, algo_source=None,
-            chorus_level=None, chorus_delay=None, chorus_freq=None, chorus_depth=None, reverb_level=None, reverb_liveness=None, reverb_damping=None, reverb_xover=None, load_patch=None, voices=None):
+            client=None, retries=None, volume=None, pitch_bend=None, filter_freq = None, resonance = None, bp0=None, bp1=None, bp0_target=None, bp1_target=None, 
+            mod_target=None, debug=None, chained_osc=None, mod_source=None, clone_osc=None, eq_l = None, eq_m = None, eq_h = None, filter_type= None, 
+            algorithm=None, ratio = None, latency_ms = None, algo_source=None, chorus_level=None, chorus_delay=None, chorus_freq=None, chorus_depth=None, 
+            reverb_level=None, reverb_liveness=None, reverb_damping=None, reverb_xover=None, load_patch=None, store_patch=None, voices=None):
 
     m = ""
+    if(store_patch is not None): return "u" + str(store_patch)
     if(time is not None): m = m + "t" + str(time)
     if(osc is not None): m = m + "v" + str(osc)
     if(wave is not None): m = m + "w" + str(wave)

--- a/src/amy.c
+++ b/src/amy.c
@@ -1568,9 +1568,10 @@ struct event amy_parse_message(char * message) {
                         case 'S': e.reset_osc = atoi(message + start); break;
                         case 's': e.pitch_bend = atoff(message + start); break;
                         case 'T': e.bp0_target = atoi(message + start);  break;
-                        case 'W': e.bp1_target = atoi(message + start);  break;
+                        case 'u': patches_store_patch(message+start); return amy_default_event(); 
                         case 'v': e.osc=((atoi(message + start)) % AMY_OSCS);  break; // allow osc wraparound
                         case 'V': e.volume = atoff(message + start); break;
+                        case 'W': e.bp1_target = atoi(message + start);  break;
                         case 'w': e.wave=atoi(message + start); break;
                         case 'x': e.eq_l = atoff(message+start); break;
                         case 'y': e.eq_m = atoff(message+start); break;

--- a/src/amy.h
+++ b/src/amy.h
@@ -484,6 +484,7 @@ extern void partials_note_off(uint16_t osc);
 extern void patches_load_patch(struct event e); 
 extern void patches_event_has_voices(struct event e);
 extern void patches_reset();
+extern void patches_store_patch(char * message);
 
 extern SAMPLE render_partials(SAMPLE *buf, uint16_t osc);
 extern SAMPLE render_custom(SAMPLE *buf, uint16_t osc) ;


### PR DESCRIPTION
We had an offline imessage design session about this, but basically, this allows anyone using AMY to add patches at runtime by giving `u1024,AMY_PATCH_STRING` where 1024 is a patch number from 1024-1055. This message must be the only thing in the string sent over. `amy.py` will parse it and send it right away, and `amy.c` will treat the rest of the message as a patch, not further messages. 

So you can do:

```
>>> import amy; amy.live()
>>> amy.send(store_patch="1024,v0S0Zv0S1Zv1w0f0.25P0.5a0.5Zv0w0f261.63,1,0,0,0,1A0,1,500,0,0,0L1Z")
>>> amy.send(voices="0",load_patch=1024)
>>> amy.send(voices='0',vel=2,note=50)
```

We divine the number of oscs used for the patch at store_patch time. If you store a new patch over an old one, that old memory is freed and re-allocated. We rely on `malloc` for all of this. 

Also recall you can "record" patches in `amy.py`, so the whole loop is:

```
>>> amy.log_patch()
>>> amy.preset(5)
>>> bass_drum = amy.retrieve_patch()
>>> bass_drum
'v0S0Zv0S1Zv1w0f0.25P0.5a0.5Zv0w0f261.63,1,0,0,0,1A0,1,500,0,0,0L1Z'
>>> amy.send(store_patch="1024,"+bass_drum)
```
